### PR TITLE
tweak 0002-hypercore metadata

### DIFF
--- a/proposals/0002-hypercore.md
+++ b/proposals/0002-hypercore.md
@@ -7,7 +7,7 @@ Type: Standard
 
 Status: Draft (as of 2018-02-21)
 
-Github PR: (add HTTPS link here after PR is opened)
+Github PR: [Draft][https://github.com/datprotocol/DEPs/pull/4]
 
 Authors: [Paul Frazee](https://github.com/pfrazee), [Mathias Buus](https://github.com/mafintosh)
 
@@ -327,4 +327,5 @@ IPFS is designed for immutable hash-addressed content, but it provides a mechani
 # Changelog
 [changelog]: #changelog
 
-- 2018-02-21: First full draft of DEP-0002 submitted for review.
+- 2018-02-19: First full draft of DEP-0002 submitted for review.
+- 2018-02-21: DEP-0002 accepted as "Draft"


### PR DESCRIPTION
This commit adds a changelog entry for the Draft being merged, and adds a github PR link. I changed the "first draft" date to what was indicated in the PR history.

I think this is pretty uncontroversial. Assigning to @pfrazee to review; i'd have to check DEP-0001 fine-print, but I think we can merge this in a day or two if there are no blocks.