### PR TITLE
Remove hyperdrive-specific material from the hypercore spec

### DIFF
--- a/proposals/0002-hypercore.md
+++ b/proposals/0002-hypercore.md
@@ -17,8 +17,6 @@ Authors: [Paul Frazee](https://github.com/pfrazee), [Mathias Buus](https://githu
 
 Hypercore Feeds are the core mechanism used in Dat. They are binary append-only streams whose contents are cryptographically hashed and signed and therefore can be verified by anyone with access to the public key of the writer.
 
-Dat uses two feeds, `content` and `metadata`. The `content` feed contains the files in your repository and `metadata` contains the metadata about the files including name, size, last modified time, etc. Dat replicates them both when synchronizing with another peer.
-
 
 # Motivation
 [motivation]: #motivation


### PR DESCRIPTION
I noticed that we have a hyperdrive-specific description of using a `metadata` and `content` feed in the intro of this spec. I think that's somewhat misleading (especially because it characterizes "Dat" as using these two feeds). I suggest we simply remove it, because the spec is fine without it.