### PR TITLE
Added functions for sign/verify to DEP 0002

### DIFF
--- a/proposals/0002-hypercore.md
+++ b/proposals/0002-hypercore.md
@@ -290,9 +290,7 @@ function sign (roots, secretKey) {
   return ed25519.detached.sign(hash, secretKey)
 }
 
-function verify (roots, signature, publicKey) {
-  var hash = root_hash(roots)
-  
+function verify (hash, signature, publicKey) {  
   return ed25519.detached.verify(signature, publicKey)
 }
 ```

--- a/proposals/0002-hypercore.md
+++ b/proposals/0002-hypercore.md
@@ -291,7 +291,7 @@ function sign (roots, secretKey) {
 }
 
 function verify (hash, signature, publicKey) {  
-  return ed25519.detached.verify(signature, publicKey)
+  return ed25519.detached.verify(hash, signature, publicKey)
 }
 ```
 

--- a/proposals/0002-hypercore.md
+++ b/proposals/0002-hypercore.md
@@ -283,6 +283,18 @@ function root_hash (roots) {
 
   return blake2b(buffers)
 }
+
+function sign (roots, secretKey) {
+  var hash = root_hash(roots)
+  
+  return ed25519.detached.sign(hash, secretKey)
+}
+
+function verify (roots, signature, publicKey) {
+  var hash = root_hash(roots)
+  
+  return ed25519.detached.verify(signature, publicKey)
+}
 ```
 
 # Parameters


### PR DESCRIPTION
Closes #39 

It wasn't instantly obvious that the hash of the roots was being signed when looking at the crypto functions, so I added the `sign` and `verify` psudocode to make it more clear for new implementations.