### PR TITLE
Clarify DNS TXT record schema modification

### DIFF
--- a/proposals/0005-dns.md
+++ b/proposals/0005-dns.md
@@ -59,11 +59,13 @@ Users have multiple options for creating a domain-name mapping.
 ## DNS TXT record
 [usage-dns-txt-record]: #usage-dns-txt-record
 
-The first option is to set a DNS TXT record at the domain which maps to a "key"-addressed Dat URL. The client will lookup this TXT record first and load the resulting Dat. That record should fit the following schema:
+The first option is to set a DNS TXT record at the domain which maps to a "key"-addressed Dat URL. The client will lookup this TXT record first and load the resulting Dat. That record should contain the following schema:
 
 ```
 datkey={key}
 ```
+
+The above schema does not have to start of the TXT record, it just has to match somewhere in the TXT record.
 
 ## .well-known/dat
 [usage-wellknown-dat]: #usage-wellknown-dat
@@ -94,7 +96,7 @@ Resolution of a Dat at `dat://{name}` should follow this process:
    - If the server responds with a malformed file (see below), return a failed lookup.
    - If the server responds with a well-formed file, store the record value in the names cache (default TTL to `3600` if not provided) and return the record value.
 
-The DNS TXT record must match this schema:
+The DNS TXT record must contain the following schema:
 
 ```
 'datkey=' [0-9a-f]{64}
@@ -107,7 +109,7 @@ The `/.well-known/dat` file must match this schema:
 ( 'TTL=' [0-9]* )?
 ```
 
-Note that DNS-record responses may not follow a pre-defined order. Therefore the results of a lookup may be undefined if multiple TXT records exist.
+Note that DNS-record responses may not follow a pre-defined order. Therefore the results of a lookup may be undefined if multiple TXT records exist. Also the DNS TXT record entry does not have to start the record, it just has to match somewhere in the TXT record.
 
 
 # Security and Privacy
@@ -166,4 +168,4 @@ Whereas traditional DNS leaks name lookups to everyone on the network, DNS-over-
 - 2018-04-27: First complete draft submitted for review
 - 2018-05-07: Add "Security and Privacy" section and rewrite DNS TXT record schema.
 - 2018-05-16: Merged as Draft after WG approval.
-
+- 2019-09-01: Clarified DNS TXT record datkey match can be anywhere in the TXT record

--- a/proposals/0005-dns.md
+++ b/proposals/0005-dns.md
@@ -65,7 +65,7 @@ The first option is to set a DNS TXT record at the domain which maps to a "key"-
 datkey={key}
 ```
 
-The above schema does not have to start of the TXT record, it just has to match somewhere in the TXT record.
+The above schema does not have to start of the TXT record, it just has to match somewhere in the TXT record. The 'key' must be a 64-character hex string.
 
 ## .well-known/dat
 [usage-wellknown-dat]: #usage-wellknown-dat


### PR DESCRIPTION
As requested in https://github.com/datprotocol/DEPs/issues/62#issuecomment-525846961 , clarified that DNS TXT record datkey match can be anywhere in the TXT record.